### PR TITLE
Clarifying target latency

### DIFF
--- a/src/content/chapters/2-slice-dat-time.mdx
+++ b/src/content/chapters/2-slice-dat-time.mdx
@@ -37,7 +37,7 @@ A *timeslice* is the duration an OS scheduler allows a process to run before pre
 > 
 > Speaking of timeslice jargon, Linux kernel devs use the [jiffy](https://github.com/torvalds/linux/blob/22b8cc3e78f5448b4c5df00303817a9137cd663f/include/linux/jiffies.h) time unit to count fixed frequency timer ticks. Among other things, jiffies are used for measuring the lengths of timeslices. Linux's jiffy frequency is typically 1000 Hz but can be configured when compiling the kernel.
 
-A slight improvement to fixed timeslice scheduling is to pick a *target latency* — the ideal longest time for a process to respond. The target latency is the time it takes for a process to resume execution after being preempted, assuming a reasonable number of processes. *This is pretty hard to visualize! Don't worry, a diagram is coming soon.*
+A slight improvement to fixed timeslice scheduling is to pick a *target latency* — the ideal longest time for a process to respond. The target latency is the time between a process starting execution, getting preempted, other processes running, and that same process starting execution again, assuming a reasonable number of processes. *This is pretty hard to visualize! Don't worry, a diagram is coming soon.*
 
 Timeslices are calculated by dividing the target latency by the total number of tasks; this is better than fixed timeslice scheduling because it eliminates wasteful task switching with fewer processes. With a target latency of 15&nbsp;ms and 10 processes, each process would get 15/10 or 1.5&nbsp;ms to run. With only 3 processes, each process gets a longer 5&nbsp;ms timeslice while still hitting the target latency.
 

--- a/src/content/chapters/2-slice-dat-time.mdx
+++ b/src/content/chapters/2-slice-dat-time.mdx
@@ -37,7 +37,7 @@ A *timeslice* is the duration an OS scheduler allows a process to run before pre
 > 
 > Speaking of timeslice jargon, Linux kernel devs use the [jiffy](https://github.com/torvalds/linux/blob/22b8cc3e78f5448b4c5df00303817a9137cd663f/include/linux/jiffies.h) time unit to count fixed frequency timer ticks. Among other things, jiffies are used for measuring the lengths of timeslices. Linux's jiffy frequency is typically 1000 Hz but can be configured when compiling the kernel.
 
-A slight improvement to fixed timeslice scheduling is to pick a *target latency* — the ideal longest time for a process to respond. The target latency is the time between a process starting execution, getting preempted, other processes running, and that same process starting execution again, assuming a reasonable number of processes. *This is pretty hard to visualize! Don't worry, a diagram is coming soon.*
+A slight improvement to fixed timeslice scheduling is to pick a *target latency* — the ideal longest time for a process to respond. The target latency is the time between a process starting execution, getting preempted, other processes executing, and that first process starting execution again, assuming a reasonable number of processes. *This is pretty hard to visualize! Don't worry, a diagram is coming soon.*
 
 Timeslices are calculated by dividing the target latency by the total number of tasks; this is better than fixed timeslice scheduling because it eliminates wasteful task switching with fewer processes. With a target latency of 15&nbsp;ms and 10 processes, each process would get 15/10 or 1.5&nbsp;ms to run. With only 3 processes, each process gets a longer 5&nbsp;ms timeslice while still hitting the target latency.
 


### PR DESCRIPTION
Not sure about this one - I thought there was some inaccuracy in saying "target latency is the time it takes for a process to resume execution after being preempted", since to me that would imply that the target latency is (end of process 1 execution -> beginning of process 1 execution), but from my understanding the target latency is (beginning of process 1 execution -> beginning of process 1 execution).

Maybe it's more convoluted with this change and thus not worth making, but I figured I would throw the suggestion out there.