### PR TITLE
Use kB instead of KB

### DIFF
--- a/src/content/chapters/5-the-translator-in-your-computer.mdx
+++ b/src/content/chapters/5-the-translator-in-your-computer.mdx
@@ -74,7 +74,7 @@ If an entry in the page table was required for every 4 KiB section of virtual me
 
 > **Aside: why the weird units?**
 > 
-> I know it's uncommon and really ugly, but I find it important to clearly differentiate between binary byte size units (powers of 2) and metric ones (powers of 10). A kilobyte, kB, is an SI unit that means 1,000 bytes. A kibibyte, KiB, is an IEC-recommended unit that means 1,024 bytes. In terms of CPUs and memory addresses, byte counts are usually powers of two because computers are binary systems. Using KB (or worse, kB) to mean 1,024 would be more ambiguous.
+> I know it's uncommon and really ugly, but I find it important to clearly differentiate between binary byte size units (powers of 2) and metric ones (powers of 10). A kilobyte, kB, is an SI unit that means 1,000 bytes. A kibibyte, KiB, is an IEC-recommended unit that means 1,024 bytes. In terms of CPUs and memory addresses, byte counts are usually powers of two because computers are binary systems. Using kB (or worse, KB) to mean 1,024 would be more ambiguous.
 
 Since it would be impossible (or at least incredibly impractical) to have sequential page table entries for the entire possible virtual memory space, CPU architectures implement *hierarchical paging*. In hierarchical paging systems, there are multiple levels of page tables of increasingly small granularity. The top level entries cover large blocks of memory and point to page tables of smaller blocks, creating a tree structure. The individual entries for blocks of 4 KiB or whatever the page size is are the leaves of the tree.
 


### PR DESCRIPTION
K is the temperature unit, Kelvin.

Quoting from Wikipedia: 

  The International System of Units (SI) defines the prefix kilo as a
  multiplication factor of 1000 (103); therefore, one kilobyte is 1000
  bytes.[1] The internationally recommended unit symbol for the kilobyte
  is kB.[1]

https://en.wikipedia.org/wiki/Kilobyte