### PR TITLE
Fixed the typo in script arguments

### DIFF
--- a/src/content/chapters/3-how-to-run-a-program.mdx
+++ b/src/content/chapters/3-how-to-run-a-program.mdx
@@ -237,7 +237,7 @@ The modified `argv` finally passed to the Node interpreter will be:
 
 <CodeBlock>
 ```c
-[ "/usr/bin/node", "--experimental-module", "./script", "B", "C" ]
+[ "/usr/bin/node", "--experimental-module", "./script", "A", "B", "C" ]
 ```
 </CodeBlock>
 </blockquote>


### PR DESCRIPTION
It looks like there are three arguments in this line:
https://github.com/hackclub/putting-the-you-in-cpu/blob/f0b3a88c80a7bd7f716f509dea58510609f3b02c/src/content/chapters/3-how-to-run-a-program.mdx#L224

But only two in this one:
https://github.com/hackclub/putting-the-you-in-cpu/blob/f0b3a88c80a7bd7f716f509dea58510609f3b02c/src/content/chapters/3-how-to-run-a-program.mdx#L240

I see no particular reason for the first argument to disappear, so there is a typo that should be fixed.