### PR TITLE
remove asterisk leading nowhere

### DIFF
--- a/src/content/chapters/5-the-translator-in-your-computer.mdx
+++ b/src/content/chapters/5-the-translator-in-your-computer.mdx
@@ -26,7 +26,7 @@ When the computer first boots up, memory accesses go directly to physical RAM. I
 
 This dictionary is actually called a *page table*, and this system of translating every memory access is called *paging*. Entries in the page table are called *pages* and each one represents how a certain chunk of virtual memory maps to RAM. These chunks are always a fixed size, and each processor architecture has a different page size. x86-64 has a default 4 KiB page size, meaning each page specifies the mapping for a block of memory 4,096 bytes long. (x86-64 also allows operating systems to enable larger 2 MiB or 4 GiB pages, which can improve address translation speed but increase memory fragmentation and waste.)
 
-The page table itself just resides in RAM. While it can contain millions of entries, each entry's size is only on the order of a couple bytes, so the page table doesn't take up too much space.*
+The page table itself just resides in RAM. While it can contain millions of entries, each entry's size is only on the order of a couple bytes, so the page table doesn't take up too much space.
 
 To enable paging at boot, the kernel first constructs the page table in RAM. Then, it stores the physical address of the start of the page table in a register called the page table base register (PTBR). Finally, the kernel enables paging to translate all memory accesses with the MMU. On x86-64, the top 20 bits of control register 3 (CR3) function as the PTBR. Bit 31 of CR0, designated PG for Paging, is set to 1 to enable paging.
 


### PR DESCRIPTION
It seems the asterisk removed in this PR was either intended as a closing asterisk for a piece of italic text, or supposed to lead the reader to a footnote, which isn't found on the page.

Thanks for your great work. It's a fun and useful read!