### PR TITLE
Fix typo in ch. 3 execveat aside

### DIFF
--- a/src/content/chapters/3-how-to-run-a-program.mdx
+++ b/src/content/chapters/3-how-to-run-a-program.mdx
@@ -27,7 +27,7 @@ Let's start with a very important system call: `execve`. It loads a program and,
 > 
 > `execve` is *actually* built on top of `execveat`, a more general syscall that runs a program with some configuration options. For simplicity, we'll mostly talk about `execve`; the only difference is that it provides some defaults to `execveat`.
 >
-> Curious what `ve` stands for? The `v` means one parameter is the vector (list) of arguments (`argv`), and the `e` means another parameter is the vector of environment variables (`envp`). Various other exec syscalls have different suffices to designate different call signatures. The `at` in `execveat` is just "at", because it specifies the location to run `execve` at.
+> Curious what `ve` stands for? The `v` means one parameter is the vector (list) of arguments (`argv`), and the `e` means another parameter is the vector of environment variables (`envp`). Various other exec syscalls have different suffixes to designate different call signatures. The `at` in `execveat` is just "at", because it specifies the location to run `execve` at.
 
 The call signature of `execve` is:
 


### PR DESCRIPTION
I might have found a typo in the `execveat` aside in chapter 3. 

I stumbled over the word _suffices_ as the plural for _suffix_.
I think it should be _suffixes_, but I'm not a native speaker/writer, so maybe I'm missing something.

[Wiktionary](https://en.wiktionary.org/wiki/suffix#Noun) tells me that the plural is indeed _suffixes_, but also notes that _suffices_ "occasionally appears":
> The plural [suffices](https://en.wiktionary.org/wiki/suffices#English) occasionally appears (including in one educational publication), but it is not a standard plural and has no basis in the Latin origin of the term.

Anyway - thanks for publishing this, I'm not done reading yet, but I'm enjoying it so far! =)