### PR TITLE
Update 3-how-to-run-a-program.mdx

### DIFF
--- a/src/content/chapters/3-how-to-run-a-program.mdx
+++ b/src/content/chapters/3-how-to-run-a-program.mdx
@@ -237,7 +237,7 @@ The modified `argv` finally passed to the Node interpreter will be:
 
 <CodeBlock>
 ```c
-[ "/usr/bin/node", "--experimental-module", "./script", "B", "C" ]
+[ "/usr/bin/node", "--experimental-module", "./script", "A", "B", "C" ]
 ```
 </CodeBlock>
 </blockquote>


### PR DESCRIPTION
Seems the A argument got lost in example?

Here's my local test to verify

```
$ ./node-test.js a b c
[ '/usr/bin/node', '/tmp/node-test.js', 'a', 'b', 'c' ]

glen@lima /tmp$ cat node-test.js 
#!/usr/bin/node --abort-on-uncaught-exception
console.log(process.argv)

glen@lima /tmp$ uname -r; rpm -q glibc
5.10.161-1
glibc-2.38-3.x86_64
```