### PR TITLE
Update magic number link to point to target format indicators

### DIFF
--- a/src/content/chapters/3-how-to-run-a-program.mdx
+++ b/src/content/chapters/3-how-to-run-a-program.mdx
@@ -159,8 +159,7 @@ The kernel's next major job is iterating through a bunch of "binfmt" (binary for
 
 Each handler exposes a `load_binary()` function which takes a `linux_binprm` struct and checks if the handler understands the program's format.
 
-This often involves looking for [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)) in the buffer, attempting to decode the start of the program (also from the buffer), and/or checking the file extension. If the handler does support the format, it prepares the program for execution and returns a success code. Otherwise, it quits early and returns an error code.
-
+This often involves looking for [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)#Format_indicator) in the buffer, attempting to decode the start of the program (also from the buffer), and/or checking the file extension. If the handler does support the format, it prepares the program for execution and returns a success code. Otherwise, it quits early and returns an error code.
 The kernel tries the `load_binary()` function of each binfmt until it reaches one that succeeds. Sometimes these will run recursively; for example, if a script has an interpreter specified and that interpreter is, itself, a script, the hierarchy might be `binfmt_script` > `binfmt_script` > `binfmt_elf` (where ELF is the executable format at the end of the chain).
 
 ### Format Highlight: Scripts


### PR DESCRIPTION
Updates the wikipedia hyperlink to target the #Format_indicator section instead of the top level numeric literal definition, matching the context of the content

This confused me at first when I was trying to understand what are magic numbers in context to binfmt handlers, and hope this PR would be helpful for future readers.